### PR TITLE
Implement call bridge varargs and tests

### DIFF
--- a/crates/lune-std-ffi/build.rs
+++ b/crates/lune-std-ffi/build.rs
@@ -22,6 +22,10 @@ fn main() {
         "cargo:rerun-if-changed={}",
         native_dir.join("luneffi_loader_windows.c").display()
     );
+    println!(
+        "cargo:rerun-if-changed={}",
+        native_dir.join("luneffi_testbridge.c").display()
+    );
 
     let mut build = cc::Build::new();
     build.include(&native_dir);
@@ -35,6 +39,8 @@ fn main() {
         build.flag_if_supported("-fvisibility=hidden");
         build.flag_if_supported("-fno-common");
     }
+
+    build.file(native_dir.join("luneffi_testbridge.c"));
 
     build.compile("luneffi_loader");
 }

--- a/crates/lune-std-ffi/src/call.rs
+++ b/crates/lune-std-ffi/src/call.rs
@@ -1,5 +1,5 @@
 use std::convert::TryFrom;
-use std::ffi::c_void;
+use std::ffi::{CString, c_void};
 
 use cfg_if::cfg_if;
 use libffi::middle::{self, Arg, Cif, CodePtr, Type};
@@ -16,6 +16,8 @@ enum TypeCode {
     UInt32,
     Int64,
     UInt64,
+    IntPtr,
+    UIntPtr,
     Float32,
     Float64,
     Pointer,
@@ -33,6 +35,22 @@ impl TypeCode {
             "uint32" | "unsigned int" => Ok(TypeCode::UInt32),
             "int64" | "sint64" | "long long" => Ok(TypeCode::Int64),
             "uint64" | "unsigned long long" => Ok(TypeCode::UInt64),
+            "long" => {
+                if cfg!(target_pointer_width = "64") && !cfg!(target_os = "windows") {
+                    Ok(TypeCode::Int64)
+                } else {
+                    Ok(TypeCode::Int32)
+                }
+            }
+            "unsigned long" => {
+                if cfg!(target_pointer_width = "64") && !cfg!(target_os = "windows") {
+                    Ok(TypeCode::UInt64)
+                } else {
+                    Ok(TypeCode::UInt32)
+                }
+            }
+            "size_t" | "uintptr_t" => Ok(TypeCode::UIntPtr),
+            "ssize_t" | "intptr_t" | "ptrdiff_t" => Ok(TypeCode::IntPtr),
             "float" => Ok(TypeCode::Float32),
             "double" => Ok(TypeCode::Float64),
             "pointer" | "void*" => Ok(TypeCode::Pointer),
@@ -53,6 +71,20 @@ impl TypeCode {
             TypeCode::UInt32 => Type::u32(),
             TypeCode::Int64 => Type::i64(),
             TypeCode::UInt64 => Type::u64(),
+            TypeCode::IntPtr => {
+                if cfg!(target_pointer_width = "64") {
+                    Type::i64()
+                } else {
+                    Type::i32()
+                }
+            }
+            TypeCode::UIntPtr => {
+                if cfg!(target_pointer_width = "64") {
+                    Type::u64()
+                } else {
+                    Type::u32()
+                }
+            }
             TypeCode::Float32 => Type::f32(),
             TypeCode::Float64 => Type::f64(),
             TypeCode::Pointer => Type::pointer(),
@@ -188,6 +220,13 @@ impl Signature {
             )));
         }
 
+        if !variadic && fixed_count != args.len() {
+            return Err(LuaError::runtime(
+                "Invalid signature: fixedCount must equal number of arguments for non-variadic functions"
+                    .to_string(),
+            ));
+        }
+
         Ok(Signature {
             abi,
             result,
@@ -290,64 +329,94 @@ fn clamp_unsigned(value: u64, bits: u32) -> LuaResult<u64> {
     Ok(value)
 }
 
-fn convert_argument(
+fn convert_typed_argument(
     value: LuaValue,
     ty: &CType,
-    string_refs: &mut Vec<LuaString>,
-) -> LuaResult<ArgValue> {
+    string_refs: &mut Vec<CString>,
+) -> LuaResult<(ArgValue, TypeCode)> {
     match ty.code {
         TypeCode::Void => Err(LuaError::runtime(
             "void type cannot be used as a function argument".to_string(),
         )),
         TypeCode::Int8 => {
             let v = clamp_signed(lua_value_to_i64(&value)?, 8)? as i8;
-            Ok(ArgValue::Int8(v))
+            Ok((ArgValue::Int8(v), TypeCode::Int8))
         }
         TypeCode::UInt8 => {
             let v = clamp_unsigned(lua_value_to_u64(&value)?, 8)? as u8;
-            Ok(ArgValue::UInt8(v))
+            Ok((ArgValue::UInt8(v), TypeCode::UInt8))
         }
         TypeCode::Int16 => {
             let v = clamp_signed(lua_value_to_i64(&value)?, 16)? as i16;
-            Ok(ArgValue::Int16(v))
+            Ok((ArgValue::Int16(v), TypeCode::Int16))
         }
         TypeCode::UInt16 => {
             let v = clamp_unsigned(lua_value_to_u64(&value)?, 16)? as u16;
-            Ok(ArgValue::UInt16(v))
+            Ok((ArgValue::UInt16(v), TypeCode::UInt16))
         }
         TypeCode::Int32 => {
             let v = clamp_signed(lua_value_to_i64(&value)?, 32)? as i32;
-            Ok(ArgValue::Int32(v))
+            Ok((ArgValue::Int32(v), TypeCode::Int32))
         }
         TypeCode::UInt32 => {
             let v = clamp_unsigned(lua_value_to_u64(&value)?, 32)? as u32;
-            Ok(ArgValue::UInt32(v))
+            Ok((ArgValue::UInt32(v), TypeCode::UInt32))
         }
-        TypeCode::Int64 => Ok(ArgValue::Int64(lua_value_to_i64(&value)?)),
-        TypeCode::UInt64 => Ok(ArgValue::UInt64(lua_value_to_u64(&value)?)),
+        TypeCode::Int64 => Ok((ArgValue::Int64(lua_value_to_i64(&value)?), TypeCode::Int64)),
+        TypeCode::UInt64 => Ok((
+            ArgValue::UInt64(lua_value_to_u64(&value)?),
+            TypeCode::UInt64,
+        )),
+        TypeCode::IntPtr => {
+            let bits = usize::BITS;
+            let value = clamp_signed(lua_value_to_i64(&value)?, bits)?;
+            if bits == 64 {
+                Ok((ArgValue::Int64(value), TypeCode::IntPtr))
+            } else {
+                Ok((ArgValue::Int32(value as i32), TypeCode::IntPtr))
+            }
+        }
+        TypeCode::UIntPtr => {
+            let bits = usize::BITS;
+            let value = clamp_unsigned(lua_value_to_u64(&value)?, bits)?;
+            if bits == 64 {
+                Ok((ArgValue::UInt64(value), TypeCode::UIntPtr))
+            } else {
+                Ok((ArgValue::UInt32(value as u32), TypeCode::UIntPtr))
+            }
+        }
         TypeCode::Float32 => match value {
-            LuaValue::Number(n) => Ok(ArgValue::Float32(n as f32)),
-            LuaValue::Integer(i) => Ok(ArgValue::Float32(i as f32)),
-            LuaValue::Boolean(b) => Ok(ArgValue::Float32(if b { 1.0 } else { 0.0 })),
+            LuaValue::Number(n) => Ok((ArgValue::Float32(n as f32), TypeCode::Float32)),
+            LuaValue::Integer(i) => Ok((ArgValue::Float32(i as f32), TypeCode::Float32)),
+            LuaValue::Boolean(b) => Ok((
+                ArgValue::Float32(if b { 1.0 } else { 0.0 }),
+                TypeCode::Float32,
+            )),
             other => Err(LuaError::runtime(format!(
                 "expected numeric value for float argument, got {other:?}"
             ))),
         },
         TypeCode::Float64 => match value {
-            LuaValue::Number(n) => Ok(ArgValue::Float64(n)),
-            LuaValue::Integer(i) => Ok(ArgValue::Float64(i as f64)),
-            LuaValue::Boolean(b) => Ok(ArgValue::Float64(if b { 1.0 } else { 0.0 })),
+            LuaValue::Number(n) => Ok((ArgValue::Float64(n), TypeCode::Float64)),
+            LuaValue::Integer(i) => Ok((ArgValue::Float64(i as f64), TypeCode::Float64)),
+            LuaValue::Boolean(b) => Ok((
+                ArgValue::Float64(if b { 1.0 } else { 0.0 }),
+                TypeCode::Float64,
+            )),
             other => Err(LuaError::runtime(format!(
                 "expected numeric value for double argument, got {other:?}"
             ))),
         },
         TypeCode::Pointer => match value {
-            LuaValue::Nil => Ok(ArgValue::Pointer(std::ptr::null_mut())),
-            LuaValue::LightUserData(ptr) => Ok(ArgValue::Pointer(ptr.0)),
-            LuaValue::Integer(i) => Ok(ArgValue::Pointer(
-                usize::try_from(i)
-                    .map_err(|_| LuaError::runtime("negative pointer value".to_string()))?
-                    as *mut c_void,
+            LuaValue::Nil => Ok((ArgValue::Pointer(std::ptr::null_mut()), TypeCode::Pointer)),
+            LuaValue::LightUserData(ptr) => Ok((ArgValue::Pointer(ptr.0), TypeCode::Pointer)),
+            LuaValue::Integer(i) => Ok((
+                ArgValue::Pointer(
+                    usize::try_from(i)
+                        .map_err(|_| LuaError::runtime("negative pointer value".to_string()))?
+                        as *mut c_void,
+                ),
+                TypeCode::Pointer,
             )),
             LuaValue::Number(n) => {
                 if !n.is_finite() {
@@ -365,13 +434,18 @@ fn convert_argument(
                         "pointer value must be integral".to_string(),
                     ));
                 }
-                Ok(ArgValue::Pointer(n as usize as *mut c_void))
+                Ok((
+                    ArgValue::Pointer(n as usize as *mut c_void),
+                    TypeCode::Pointer,
+                ))
             }
             LuaValue::String(s) => {
-                let bytes = s.as_bytes();
-                let ptr = bytes.as_ptr() as *mut c_void;
-                string_refs.push(s);
-                Ok(ArgValue::Pointer(ptr))
+                let owned = CString::new(s.as_bytes().as_ref()).map_err(|_| {
+                    LuaError::runtime("string argument contains NUL byte".to_string())
+                })?;
+                let ptr = owned.as_ptr() as *mut c_void;
+                string_refs.push(owned);
+                Ok((ArgValue::Pointer(ptr), TypeCode::Pointer))
             }
             other => Err(LuaError::runtime(format!(
                 "cannot convert value {other:?} to pointer argument"
@@ -380,44 +454,140 @@ fn convert_argument(
     }
 }
 
+fn convert_variadic_argument(
+    value: LuaValue,
+    string_refs: &mut Vec<CString>,
+) -> LuaResult<(ArgValue, TypeCode)> {
+    // TODO(ffi/callbridge): support full LuaJIT vararg semantics including cdata promotion rules
+    // and soft-float calling conventions.
+    match value {
+        LuaValue::Nil => Ok((ArgValue::Pointer(std::ptr::null_mut()), TypeCode::Pointer)),
+        LuaValue::LightUserData(ptr) => Ok((ArgValue::Pointer(ptr.0), TypeCode::Pointer)),
+        LuaValue::String(s) => {
+            let owned = CString::new(s.as_bytes().as_ref())
+                .map_err(|_| LuaError::runtime("string argument contains NUL byte".to_string()))?;
+            let ptr = owned.as_ptr() as *mut c_void;
+            string_refs.push(owned);
+            Ok((ArgValue::Pointer(ptr), TypeCode::Pointer))
+        }
+        LuaValue::Boolean(b) => {
+            let value = if b { 1 } else { 0 };
+            Ok((ArgValue::Int32(value), TypeCode::Int32))
+        }
+        LuaValue::Integer(i) => {
+            if cfg!(target_pointer_width = "64") {
+                Ok((ArgValue::Int64(i), TypeCode::Int64))
+            } else {
+                let clamped = clamp_signed(i, 32)? as i32;
+                Ok((ArgValue::Int32(clamped), TypeCode::Int32))
+            }
+        }
+        LuaValue::Number(n) => {
+            if !n.is_finite() {
+                return Err(LuaError::runtime(
+                    "numeric argument must be finite".to_string(),
+                ));
+            }
+            Ok((ArgValue::Float64(n), TypeCode::Float64))
+        }
+        other => Err(LuaError::runtime(format!(
+            "cannot infer C type for variadic argument {other:?}"
+        ))),
+    }
+}
+
+fn convert_argument(
+    value: LuaValue,
+    ty: Option<&CType>,
+    string_refs: &mut Vec<CString>,
+) -> LuaResult<(ArgValue, TypeCode)> {
+    match ty {
+        Some(ty) => convert_typed_argument(value, ty, string_refs),
+        None => convert_variadic_argument(value, string_refs),
+    }
+}
+
 fn collect_arguments(
     args_table: LuaTable,
     signature: &Signature,
-) -> LuaResult<(Vec<ArgValue>, Vec<LuaString>)> {
-    let declared_count = signature.args.len();
+) -> LuaResult<(Vec<ArgValue>, Vec<Type>, Vec<CString>)> {
     let explicit_n = args_table.get::<Option<u32>>("n")?.map(|n| n as usize);
     let arg_count = explicit_n.unwrap_or_else(|| args_table.raw_len() as usize);
 
-    if arg_count != declared_count {
-        return Err(LuaError::runtime(format!(
-            "function expected {declared_count} argument(s) but received {arg_count}"
-        )));
+    if signature.variadic {
+        if arg_count < signature.fixed_count {
+            return Err(LuaError::runtime(format!(
+                "function expected at least {} argument(s) but received {arg_count}",
+                signature.fixed_count
+            )));
+        }
+    } else {
+        let expected = signature.args.len();
+        if arg_count != expected {
+            return Err(LuaError::runtime(format!(
+                "function expected {expected} argument(s) but received {arg_count}"
+            )));
+        }
     }
 
     let mut values = Vec::with_capacity(arg_count);
+    let mut arg_types = Vec::with_capacity(arg_count);
     let mut string_refs = Vec::new();
 
-    for (index, ty) in signature.args.iter().enumerate() {
+    for index in 0..arg_count {
         let value = args_table.raw_get::<LuaValue>(index as i64 + 1)?;
-        let arg = convert_argument(value, ty, &mut string_refs)?;
+        let type_hint = signature.args.get(index);
+
+        if index < signature.fixed_count {
+            let ty = type_hint.ok_or_else(|| {
+                LuaError::runtime(format!(
+                    "missing type information for fixed argument {}",
+                    index + 1
+                ))
+            })?;
+
+            let (arg, _) = convert_argument(value, Some(ty), &mut string_refs)?;
+            arg_types.push(ty.to_libffi_type());
+            values.push(arg);
+            continue;
+        }
+
+        if !signature.variadic {
+            let ty = type_hint.ok_or_else(|| {
+                LuaError::runtime(format!(
+                    "missing type information for argument {}",
+                    index + 1
+                ))
+            })?;
+            let (arg, _) = convert_argument(value, Some(ty), &mut string_refs)?;
+            arg_types.push(ty.to_libffi_type());
+            values.push(arg);
+            continue;
+        }
+
+        let (arg, inferred) = convert_argument(value, type_hint, &mut string_refs)?;
+        let ffi_type = match type_hint {
+            Some(ty) => ty.to_libffi_type(),
+            None => inferred.to_libffi_type(),
+        };
+        arg_types.push(ffi_type);
         values.push(arg);
     }
 
-    Ok((values, string_refs))
+    Ok((values, arg_types, string_refs))
 }
 
-fn build_cif(signature: &Signature) -> Cif {
-    let arg_types: Vec<Type> = signature.args.iter().map(CType::to_libffi_type).collect();
+fn build_cif(signature: &Signature, arg_types: &[Type]) -> Cif {
     let result_type = signature.result.to_libffi_type();
 
     let mut cif = if signature.variadic {
         Cif::new_variadic(
-            arg_types.clone().into_iter(),
+            arg_types.iter().cloned(),
             signature.fixed_count,
             result_type,
         )
     } else {
-        Cif::new(arg_types.into_iter(), result_type)
+        Cif::new(arg_types.iter().cloned(), result_type)
     };
 
     if let AbiChoice::Explicit(abi) = signature.abi {
@@ -477,6 +647,28 @@ fn call_with_signature(
                     Ok(LuaValue::Number(value as f64))
                 }
             }
+            TypeCode::IntPtr => {
+                if cfg!(target_pointer_width = "64") {
+                    let value: i64 = cif.call(code_ptr, args);
+                    Ok(LuaValue::Integer(value))
+                } else {
+                    let value: i32 = cif.call(code_ptr, args);
+                    Ok(LuaValue::Integer(value.into()))
+                }
+            }
+            TypeCode::UIntPtr => {
+                if cfg!(target_pointer_width = "64") {
+                    let value: u64 = cif.call(code_ptr, args);
+                    if value <= i64::MAX as u64 {
+                        Ok(LuaValue::Integer(value as i64))
+                    } else {
+                        Ok(LuaValue::Number(value as f64))
+                    }
+                } else {
+                    let value: u32 = cif.call(code_ptr, args);
+                    Ok(LuaValue::Integer((value as i64).into()))
+                }
+            }
             TypeCode::Float32 => {
                 let value: f32 = cif.call(code_ptr, args);
                 Ok(LuaValue::Number(value as f64))
@@ -504,8 +696,129 @@ pub fn call(
     args_table: LuaTable,
 ) -> LuaResult<LuaValue> {
     let signature = Signature::from_table(signature_table)?;
-    let (arg_values, _string_refs) = collect_arguments(args_table, &signature)?;
+    let (arg_values, arg_types, _owned_strings) = collect_arguments(args_table, &signature)?;
     let arg_refs: Vec<Arg> = arg_values.iter().map(ArgValue::as_arg).collect();
-    let cif = build_cif(&signature);
+    let cif = build_cif(&signature, &arg_types);
     call_with_signature(&signature, func, cif, &arg_refs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CStr;
+    use std::os::raw::{c_char, c_void};
+
+    unsafe extern "C" {
+        fn luneffi_test_add_ints(a: i32, b: i32) -> i32;
+        fn luneffi_test_variadic_sum(count: i32, ...) -> i32;
+        fn luneffi_test_variadic_format(
+            buffer: *mut c_char,
+            size: usize,
+            fmt: *const c_char,
+            ...
+        ) -> i32;
+    }
+
+    fn make_signature(
+        lua: &Lua,
+        result: &str,
+        args: &[&str],
+        variadic: bool,
+        fixed: usize,
+    ) -> LuaResult<LuaTable> {
+        let signature = lua.create_table()?;
+        signature.set("result", result)?;
+
+        let args_table = lua.create_table()?;
+        for (index, code) in args.iter().enumerate() {
+            args_table.set(index + 1, *code)?;
+        }
+        signature.set("args", args_table)?;
+
+        if variadic {
+            signature.set("variadic", true)?;
+            signature.set("fixedCount", fixed as u32)?;
+        }
+
+        Ok(signature)
+    }
+
+    fn pack_args(lua: &Lua, values: Vec<LuaValue>) -> LuaResult<LuaTable> {
+        let len = values.len();
+        let args = lua.create_table()?;
+        for (index, value) in values.into_iter().enumerate() {
+            args.raw_set((index + 1) as i64, value)?;
+        }
+        args.set("n", len)?;
+        Ok(args)
+    }
+
+    #[test]
+    fn call_simple_add() -> LuaResult<()> {
+        let lua = Lua::new();
+        let signature = make_signature(&lua, "int32", &["int32", "int32"], false, 2)?;
+        let args = pack_args(&lua, vec![LuaValue::Integer(12), LuaValue::Integer(30)])?;
+        let func = LuaLightUserData(luneffi_test_add_ints as *const () as *mut c_void);
+        let result = call(&lua, func, signature, args)?;
+        match result {
+            LuaValue::Integer(value) => assert_eq!(value, 42),
+            other => panic!("unexpected result: {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn call_variadic_sum_infers_arguments() -> LuaResult<()> {
+        let lua = Lua::new();
+        let signature = make_signature(&lua, "int32", &["int32"], true, 1)?;
+        let args = pack_args(
+            &lua,
+            vec![
+                LuaValue::Integer(3),
+                LuaValue::Integer(10),
+                LuaValue::Integer(20),
+                LuaValue::Integer(5),
+            ],
+        )?;
+        let func = LuaLightUserData(luneffi_test_variadic_sum as *const () as *mut c_void);
+        let result = call(&lua, func, signature, args)?;
+        match result {
+            LuaValue::Integer(value) => assert_eq!(value, 35),
+            other => panic!("unexpected result: {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn call_variadic_format_handles_strings() -> LuaResult<()> {
+        let lua = Lua::new();
+        let signature = make_signature(&lua, "int32", &["pointer", "size_t", "pointer"], true, 3)?;
+
+        let mut buffer: [c_char; 64] = [0; 64];
+        let format = lua.create_string("%d + %d = %d")?;
+
+        let args = pack_args(
+            &lua,
+            vec![
+                LuaValue::LightUserData(LuaLightUserData(buffer.as_mut_ptr() as *mut c_void)),
+                LuaValue::Integer(buffer.len() as i64),
+                LuaValue::String(format),
+                LuaValue::Integer(4),
+                LuaValue::Integer(7),
+                LuaValue::Integer(11),
+            ],
+        )?;
+
+        let func = LuaLightUserData(luneffi_test_variadic_format as *const () as *mut c_void);
+        let result = call(&lua, func, signature, args)?;
+        let written = match result {
+            LuaValue::Integer(value) => value,
+            other => panic!("unexpected result: {other:?}"),
+        };
+        assert!(written >= 0);
+
+        let c_str = unsafe { CStr::from_ptr(buffer.as_ptr()) };
+        assert_eq!(c_str.to_str().unwrap(), "4 + 7 = 11");
+        Ok(())
+    }
 }

--- a/packages/ffi/PROGRESS.md
+++ b/packages/ffi/PROGRESS.md
@@ -2,7 +2,7 @@
 
 - [x] Create `@lune/ffi` package scaffolding (src, tests, examples, docs, CI)
 - [x] Implement loader native shim (POSIX/Windows) + Luau wrapper
-- [ ] Implement call bridge (cdecl + Windows stdcall/ms_abi), basic varargs *(in progress: native call trampoline + debug invocation helpers; TODO varargs + integration with parser)*
+- [x] Implement call bridge (cdecl + Windows stdcall/ms_abi), basic varargs *(TODO: richer cdata varargs + parser integration)*
 - [ ] `ffi.cdef` parser (typedefs, enums, structs/unions, bitfields basic)
 - [ ] `ffi.new`, `ffi.typeof`, `ffi.cast`, `ffi.string`
 - [ ] `ffi.sizeof`, `ffi.alignof`, `ffi.offsetof`

--- a/packages/ffi/native/luneffi_testbridge.c
+++ b/packages/ffi/native/luneffi_testbridge.c
@@ -1,0 +1,34 @@
+#include "luneffi_loader.h"
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdio.h>
+
+int luneffi_test_add_ints(int a, int b) {
+    return a + b;
+}
+
+int luneffi_test_variadic_sum(int count, ...) {
+    va_list args;
+    va_start(args, count);
+
+    long long total = 0;
+    for (int index = 0; index < count; ++index) {
+        total += va_arg(args, int);
+    }
+
+    va_end(args);
+    return (int)total;
+}
+
+int luneffi_test_variadic_format(char* buffer, size_t size, const char* fmt, ...) {
+    if (buffer == NULL || size == 0) {
+        return -1;
+    }
+
+    va_list args;
+    va_start(args, fmt);
+    int written = vsnprintf(buffer, size, fmt, args);
+    va_end(args);
+    return written;
+}


### PR DESCRIPTION
## Summary
- extend the Rust call bridge with pointer-width integer support, Lua string copies, and dynamic vararg inference while rebuilding CIFs per invocation for variadic calls
- add native test shims and Rust unit tests exercising fixed-arity and variadic FFI calls from Luau via libffi
- wire the new shim into the build script and update project progress tracking

## Testing
- `cargo test -p lune-std-ffi`

------
https://chatgpt.com/codex/tasks/task_e_68cbc411bec88326991a31be97f3a029