### PR TITLE
Add ffi platform metadata, caching, and finalizer support

### DIFF
--- a/packages/ffi/PROGRESS.md
+++ b/packages/ffi/PROGRESS.md
@@ -6,9 +6,9 @@
 - [x] `ffi.cdef` parser (typedefs, enums, structs/unions, bitfields basic) *(arrays/nested declarators still TODO)*
 - [x] `ffi.new`, `ffi.typeof`, `ffi.cast`, `ffi.string`
 - [x] `ffi.sizeof`, `ffi.alignof`, `ffi.offsetof`
-- [ ] `ffi.C`, `ffi.load`, symbol cache
-- [ ] `ffi.metatype`, `ffi.gc`
-- [ ] `ffi.abi`, `ffi.os`, `ffi.arch`
+- [x] `ffi.C`, `ffi.load`, symbol cache
+- [x] `ffi.metatype`, `ffi.gc`
+- [x] `ffi.abi`, `ffi.os`, `ffi.arch`
 - [ ] Callback trampolines (Luau → C function pointers) + GC safety
 - [ ] Error/errno handling
 - [ ] Unit & integration tests (incl. tiny C test lib built in CI)

--- a/packages/ffi/README.md
+++ b/packages/ffi/README.md
@@ -1,13 +1,55 @@
 # @lune/ffi
 
-> Work in progress Luau FFI inspired by LuaJIT.
+Luau Foreign Function Interface inspired by LuaJIT's excellent FFI while remaining idiomatic to the Lune ecosystem.
 
-## Status
+> **Status:** Work in progress. See `PROGRESS.md` for the full roadmap.
 
-This package is under active development. See `PROGRESS.md` for the project checklist.
+## Quickstart
 
-## Current Capabilities
+```luau
+local ffi = require("@lune/ffi")
 
-- `ffi.cdef` can register C function prototypes, typedef aliases, and basic struct/union/enum definitions (arrays and advanced declarators are still TODO).
-- A lightweight Luau test harness lives under `packages/ffi/tests/_runner.luau` and can be executed with `cargo run -p lune -- run packages/ffi/tests/_runner.luau`.
+local counter = 0
+local value = ffi.new("int", 1337)
+ffi.gc(value, function()
+    counter += 1
+end)
+
+local intPtr = ffi.metatype("int*", {
+    __tostring = function(self)
+        local raw = rawget(self, "__ptr")
+        return raw and ("int*" .. tostring(raw)) or "int*<null>"
+    end,
+})
+
+local ptr = ffi.cast(intPtr, value)
+print(tostring(ptr))
+print("Platform", ffi.os, ffi.arch)
+```
+
+Run the local spec suite:
+
+```bash
+cargo run -p lune -- run packages/ffi/tests/_runner.luau
+```
+
+## Compatibility Snapshot
+
+| Feature | Status | Notes |
+| --- | --- | --- |
+| `ffi.cdef` | ⚠️ | Typedefs, enums, structs/unions, function prototypes supported (arrays/nested declarators pending). |
+| `ffi.C` / `ffi.load` | ✅ | Process handle exposed; named libraries cached with automatic `dlclose` on GC. |
+| `ffi.new` / `ffi.cast` / `ffi.typeof` | ⚠️ | Primitives and pointers supported; structured allocations are TODO. |
+| `ffi.gc` | ✅ | Finalizers on cdata tables; lightuserdata support TODO. |
+| `ffi.metatype` | ⚠️ | Metamethods for pointers/records cached; field access helpers forthcoming. |
+| `ffi.string` | ✅ | Reads NUL-terminated or length-bounded buffers. |
+| `ffi.sizeof` / `ffi.alignof` / `ffi.offsetof` | ✅ | Matches platform primitives; complex bitfield offsets still TODO. |
+| `ffi.abi` / `ffi.os` / `ffi.arch` | ✅ | Normalised strings/flags mirroring LuaJIT identifiers. |
+| Call bridge | ⚠️ | LibFFI-backed; structured returns/varargs extensions tracked separately. |
+
+## Testing & Development
+
+- Specs live under `packages/ffi/tests`. The `_runner.luau` harness discovers and executes the suite.
+- Native shims are located in `packages/ffi/native` and compiled as part of the Rust crate `lune-std-ffi`.
+- Use `cargo fmt` and `stylua` to keep Rust and Luau code formatted.
 

--- a/packages/ffi/src/init.luau
+++ b/packages/ffi/src/init.luau
@@ -21,11 +21,27 @@ if type(PRIMITIVE_LAYOUTS) ~= "table" then
     error("native.primitiveLayout must be a table", 2)
 end
 
+local PLATFORM_OS = native.platformOS
+if type(PLATFORM_OS) ~= "string" then
+    error("native.platformOS must be a string", 2)
+end
+
+local PLATFORM_ARCH = native.platformArch
+if type(PLATFORM_ARCH) ~= "string" then
+    error("native.platformArch must be a string", 2)
+end
+
+local ABI_FLAGS = native.abiInfo
+if type(ABI_FLAGS) ~= "table" then
+    error("native.abiInfo must be a table", 2)
+end
+
 type LibraryState = {
     handle: NativeHandle?,
     name: string,
     autoClose: boolean,
     symbols: { [string]: any },
+    cacheKey: string?,
 }
 
 type CTypeDescriptor = {
@@ -47,9 +63,20 @@ local registry = {
     functions = {} :: { [string]: FunctionSignature },
 }
 
+local libraryCache = setmetatable({}, { __mode = "v" }) :: { [string]: any }
+
 local function trim(value: string): string
     local stripped = value:gsub("^%s+", "")
     return stripped:gsub("%s+$", "")
+end
+
+local function warn_if_available(message: string)
+    local maybeWarn = rawget(_G, "warn")
+    if type(maybeWarn) == "function" then
+        maybeWarn(message)
+    else
+        print(message)
+    end
 end
 
 type CType = {
@@ -62,6 +89,7 @@ type CType = {
     fields: { RecordField }?,
     fieldMap: { [string]: RecordField }?,
     values: { EnumEntry }?,
+    metatype: { [string]: any }?,
 }
 
 type TypeResolveResult = CType
@@ -1146,65 +1174,109 @@ return string.format("cfunction: %s", self.__name)
 end
 
 local function create_symbol_proxy(name: string, ptr: NativeHandle)
-return setmetatable({
-__name = name,
-__ptr = ptr,
-}, symbol_mt)
+    return setmetatable({
+        __name = name,
+        __ptr = ptr,
+    }, symbol_mt)
 end
 
 local library_mt = {}
 library_mt.__index = function(self, key)
-local state: LibraryState = rawget(self, "__state")
-local method = library_mt[key]
-if method then
-return method
-end
-local cached = state.symbols[key]
-if cached then
-return cached
-end
-local handle = ensure_handle(state)
-local sym, err = native.dlsym(handle, key)
-if not sym then
-error(err or string.format("Symbol '%s' not found", key), 2)
-end
-local proxy = create_symbol_proxy(key, sym)
-state.symbols[key] = proxy
-return proxy
+    local state: LibraryState = rawget(self, "__state")
+    if not state then
+        error("missing library state", 2)
+    end
+
+    local method = library_mt[key]
+    if method then
+        return method
+    end
+
+    local cached = state.symbols[key]
+    if cached then
+        return cached
+    end
+
+    local handle = ensure_handle(state)
+    local sym, err = native.dlsym(handle, key)
+    if not sym then
+        error(err or string.format("Symbol '%s' not found", key), 2)
+    end
+    local proxy = create_symbol_proxy(key, sym)
+    state.symbols[key] = proxy
+    return proxy
 end
 
 function library_mt:close(): boolean
-local state: LibraryState = rawget(self, "__state")
-if not state.handle then
-return false
-end
-local handle = state.handle
-state.handle = nil
-state.symbols = {}
-if state.autoClose then
-native.dlclose(handle)
-return true
-end
-return false
+    local state: LibraryState = rawget(self, "__state")
+    if not state then
+        return false
+    end
+
+    local handle = state.handle
+    if not handle then
+        return false
+    end
+
+    if not state.autoClose then
+        return false
+    end
+
+    local ok, err = pcall(native.dlclose, handle)
+    if not ok then
+        error(err, 2)
+    end
+
+    state.handle = nil
+    state.symbols = {}
+    if state.cacheKey then
+        libraryCache[state.cacheKey] = nil
+    end
+    return true
 end
 
 function library_mt:__tostring()
-local state: LibraryState = rawget(self, "__state")
-if state.handle then
-return string.format("clibrary: %s", state.name)
-else
-return string.format("clibrary: %s (closed)", state.name)
-end
+    local state: LibraryState = rawget(self, "__state")
+    if state and state.handle then
+        return string.format("clibrary: %s", state.name)
+    elseif state then
+        return string.format("clibrary: %s (closed)", state.name)
+    end
+    return "clibrary: <invalid>"
 end
 
-local function wrap_library(handle: NativeHandle, name: string, autoClose: boolean)
-local state: LibraryState = {
-handle = handle,
-name = name,
-autoClose = autoClose,
-symbols = {},
-}
-return setmetatable({ __state = state }, library_mt)
+function library_mt:__gc()
+    local state: LibraryState = rawget(self, "__state")
+    if not state or not state.autoClose then
+        return
+    end
+
+    local handle = state.handle
+    if not handle then
+        return
+    end
+
+    state.handle = nil
+    state.symbols = {}
+    if state.cacheKey then
+        libraryCache[state.cacheKey] = nil
+    end
+
+    local ok, err = pcall(native.dlclose, handle)
+    if not ok then
+        warn_if_available(string.format("ffi: failed to close library '%s': %s", state.name, tostring(err)))
+    end
+end
+
+local function wrap_library(handle: NativeHandle, name: string, autoClose: boolean, cacheKey: string?)
+    local state: LibraryState = {
+        handle = handle,
+        name = name,
+        autoClose = autoClose,
+        symbols = {},
+        cacheKey = cacheKey,
+    }
+    return setmetatable({ __state = state }, library_mt)
 end
 
 local function is_cdata(value: any): boolean
@@ -1500,14 +1572,137 @@ local function unwrap_pointer(value: any): NativeHandle
 end
 
 local cdata_mt = {}
-cdata_mt.__index = cdata_mt
+
+local function get_descriptor_meta(descriptor: CType): { [string]: any }?
+    local meta = descriptor.metatype
+    if type(meta) == "table" then
+        return meta
+    end
+    return nil
+end
+
+local function get_object_meta(self): { [string]: any }?
+    local meta = rawget(self, "__meta")
+    if type(meta) == "table" then
+        return meta
+    end
+    local descriptor: CType? = rawget(self, "__ctype")
+    if descriptor then
+        local descriptorMeta = get_descriptor_meta(descriptor)
+        if descriptorMeta then
+            rawset(self, "__meta", descriptorMeta)
+            return descriptorMeta
+        end
+    end
+    return nil
+end
+
+function cdata_mt:__index(key)
+    local meta = get_object_meta(self)
+    if meta then
+        local indexer = rawget(meta, "__index")
+        if type(indexer) == "function" then
+            return indexer(self, key)
+        elseif type(indexer) == "table" then
+            local value = indexer[key]
+            if value ~= nil then
+                return value
+            end
+        end
+    end
+    return rawget(cdata_mt, key)
+end
+
+function cdata_mt:__newindex(key, value)
+    local meta = get_object_meta(self)
+    if meta then
+        local handler = rawget(meta, "__newindex")
+        if type(handler) == "function" then
+            handler(self, key, value)
+            return
+        elseif type(handler) == "table" then
+            handler[key] = value
+            return
+        end
+    end
+    rawset(self, key, value)
+end
 
 function cdata_mt:__tostring()
+    local meta = get_object_meta(self)
+    if meta then
+        local handler = rawget(meta, "__tostring")
+        if type(handler) == "function" then
+            return handler(self)
+        end
+    end
+
     local descriptor: CType? = rawget(self, "__ctype")
     local ptr: NativeHandle? = rawget(self, "__ptr")
     local name = if descriptor and descriptor.name then descriptor.name else "<unknown>"
     local pointerRepr = if ptr then tostring(ptr) else "NULL"
     return string.format("cdata<%s>:%s", name, pointerRepr)
+end
+
+function cdata_mt:__len()
+    local meta = get_object_meta(self)
+    if meta then
+        local handler = rawget(meta, "__len")
+        if type(handler) == "function" then
+            return handler(self)
+        end
+    end
+    error("length operation not defined for cdata", 2)
+end
+
+function cdata_mt:__call(...)
+    local meta = get_object_meta(self)
+    if meta then
+        local handler = rawget(meta, "__call")
+        if type(handler) == "function" then
+            return handler(self, ...)
+        end
+    end
+    error("attempt to call cdata value", 2)
+end
+
+function cdata_mt:__eq(other)
+    local meta = get_object_meta(self)
+    if meta then
+        local handler = rawget(meta, "__eq")
+        if type(handler) == "function" then
+            return handler(self, other)
+        end
+    end
+
+    if type(other) == "table" and is_cdata(other) then
+        local selfPtr = rawget(self, "__ptr")
+        local otherPtr = rawget(other, "__ptr")
+        if selfPtr ~= nil and otherPtr ~= nil then
+            return selfPtr == otherPtr
+        end
+    end
+
+    return rawequal(self, other)
+end
+
+function cdata_mt:__gc()
+    local finalizer = rawget(self, "__finalizer")
+    if type(finalizer) == "function" then
+        rawset(self, "__finalizer", nil)
+        local ok, err = pcall(finalizer, self)
+        if not ok then
+            warn_if_available(string.format("ffi: error in cdata finalizer: %s", tostring(err)))
+        end
+    end
+
+    if rawget(self, "__owned") then
+        local ptr = rawget(self, "__ptr")
+        if ptr ~= nil then
+            native.free(ptr :: NativeHandle)
+            rawset(self, "__ptr", nil)
+        end
+    end
 end
 
 local function create_cdata(descriptor: CType, pointer: NativeHandle?, owned: boolean): any
@@ -1519,6 +1714,11 @@ local function create_cdata(descriptor: CType, pointer: NativeHandle?, owned: bo
 
     if pointer then
         rawset(object, "__ptr", pointer)
+    end
+
+    local meta = get_descriptor_meta(descriptor)
+    if meta then
+        rawset(object, "__meta", meta)
     end
 
     return setmetatable(object, cdata_mt)
@@ -1558,20 +1758,47 @@ function ffi.cdef(header: string)
     end
 end
 
-function ffi.load(libnameOrPath: string?): any
-if libnameOrPath ~= nil and type(libnameOrPath) ~= "string" then
-error("ffi.load expects a string or nil", 2)
-end
-local ok, handleOrErr = pcall(native.dlopen, libnameOrPath)
-if not ok then
-error(handleOrErr, 2)
-end
-local handle = handleOrErr :: NativeHandle
-local name = libnameOrPath or "<process>"
-return wrap_library(handle, name, libnameOrPath ~= nil)
+local function create_process_library(): any
+    local ok, result = pcall(native.dlopen, nil)
+    if not ok then
+        error(result, 2)
+    end
+    return wrap_library(result :: NativeHandle, "<process>", false, nil)
 end
 
-ffi.C = wrap_library(native.dlopen(nil), "<process>", false)
+ffi.C = create_process_library()
+
+function ffi.load(libnameOrPath: string?): any
+    if libnameOrPath == nil then
+        return ffi.C
+    end
+    if type(libnameOrPath) ~= "string" then
+        error("ffi.load expects a string or nil", 2)
+    end
+
+    local trimmed = trim(libnameOrPath)
+    if trimmed == "" then
+        error("ffi.load expects a non-empty library name", 2)
+    end
+
+    local cached = libraryCache[trimmed]
+    if cached then
+        local state: LibraryState? = rawget(cached, "__state")
+        if state and state.handle then
+            return cached
+        end
+        libraryCache[trimmed] = nil
+    end
+
+    local ok, handleOrErr = pcall(native.dlopen, libnameOrPath)
+    if not ok then
+        error(handleOrErr, 2)
+    end
+    local handle = handleOrErr :: NativeHandle
+    local library = wrap_library(handle, libnameOrPath, true, trimmed)
+    libraryCache[trimmed] = library
+    return library
+end
 
 function ffi.typeof(spec: any): CType
     return resolve_ctype(spec)
@@ -1659,12 +1886,47 @@ function ffi.string(value: any, len: number?): string
     return result
 end
 
-function ffi.gc(_: any, _fn: ((any) -> ())?)
-todo("ffi.gc")
+function ffi.gc(value: any, finalizer: ((any) -> ())?)
+    local valueType = type(value)
+    if valueType == "userdata" then
+        error("TODO(@lune/ffi/gc): finalizers for lightuserdata not supported yet", 2)
+    end
+    if not is_cdata(value) then
+        error("ffi.gc expects a cdata value", 2)
+    end
+    if finalizer ~= nil and type(finalizer) ~= "function" then
+        error("ffi.gc finalizer must be a function or nil", 2)
+    end
+
+    if finalizer then
+        rawset(value, "__finalizer", finalizer)
+    else
+        rawset(value, "__finalizer", nil)
+    end
+
+    return value
 end
 
-function ffi.metatype(_: any, _methods: { [string]: any })
-todo("ffi.metatype")
+function ffi.metatype(spec: any, methods: { [string]: any })
+    if methods == nil then
+        error("ffi.metatype expects a metamethod table", 2)
+    end
+    if type(methods) ~= "table" then
+        error("ffi.metatype metamethods must be provided as a table", 2)
+    end
+
+    local descriptor = resolve_ctype(spec)
+    if descriptor.kind ~= "struct" and descriptor.kind ~= "union" and descriptor.kind ~= "pointer" then
+        error(string.format("ffi.metatype does not support type '%s' yet", descriptor.name), 2)
+    end
+
+    local copy = {}
+    for key, value in pairs(methods) do
+        copy[key] = value
+    end
+
+    descriptor.metatype = copy
+    return descriptor
 end
 
 function ffi.sizeof(spec: any): number
@@ -1711,11 +1973,29 @@ function ffi.offsetof(spec: any, field: string): number
 end
 
 function ffi.abi(...: string): boolean
-todo("ffi.abi")
+    local count = select("#", ...)
+    if count == 0 then
+        error("ffi.abi expects at least one attribute", 2)
+    end
+
+    local results = table.create(count)
+    for index = 1, count do
+        local attr = select(index, ...)
+        if type(attr) ~= "string" then
+            error("ffi.abi attribute must be a string", 2)
+        end
+        local value = ABI_FLAGS[attr]
+        if value == nil then
+            error(string.format("unknown ABI attribute '%s'", attr), 2)
+        end
+        results[index] = value == true
+    end
+
+    return table.unpack(results, 1, count)
 end
 
-ffi.os = "unknown"
-ffi.arch = "unknown"
+ffi.os = PLATFORM_OS
+ffi.arch = PLATFORM_ARCH
 
 local debug = {}
 

--- a/packages/ffi/tests/runtime_spec.luau
+++ b/packages/ffi/tests/runtime_spec.luau
@@ -100,4 +100,94 @@ return function(ctx)
         assert(type(missingErr) == "string", "expected error when field missing")
         assert(missingErr:find("field 'missing' not found", 1, true) ~= nil)
     end)
+
+    test("ffi.C resolves process symbols and ffi.load returns the default library", function()
+        local defaultLib = ffi.load(nil)
+        assertEqual(defaultLib, ffi.C)
+
+        local repr = tostring(defaultLib)
+        assert(type(repr) == "string" and repr:find("clibrary:", 1, true) == 1)
+
+        local ok, err = pcall(function()
+            return defaultLib.__definitely_missing_symbol
+        end)
+        assertEqual(ok, false)
+        assert(type(err) == "string")
+        assert(
+            err:find("Symbol", 1, true) ~= nil
+                or err:find("symbol", 1, true) ~= nil,
+            "expected lookup failure to mention missing symbol"
+        )
+    end)
+
+    test("ffi.gc attaches and triggers finalizers exactly once", function()
+        local finalizeCount = 0
+        do
+            local value = ffi.new("int", 64)
+            ffi.gc(value, function(obj)
+                finalizeCount += 1
+                assertEqual(ffi.typeof(obj).code, "int")
+            end)
+
+            local mt = getmetatable(value)
+            assert(type(mt) == "table" and type(mt.__gc) == "function")
+            mt.__gc(value)
+        end
+
+        assertEqual(finalizeCount, 1)
+
+        do
+            local value = ffi.new("int", 7)
+            ffi.gc(value, function()
+                finalizeCount += 10
+            end)
+            ffi.gc(value, nil)
+
+            local mt = getmetatable(value)
+            assert(type(mt) == "table" and type(mt.__gc) == "function")
+            mt.__gc(value)
+        end
+
+        assertEqual(finalizeCount, 1)
+    end)
+
+    test("ffi.metatype customizes pointer behaviour", function()
+        local intPointer = ffi.typeof("int*")
+        ffi.metatype(intPointer, {
+            __tostring = function(self)
+                local ptr = rawget(self, "__ptr")
+                if ptr == nil then
+                    return "int*<null>"
+                end
+                return "int*" .. tostring(ptr)
+            end,
+        })
+
+        local nullPtr = ffi.new("int*")
+        assertEqual(tostring(nullPtr), "int*<null>")
+
+        local value = ffi.new("int", 9)
+        local alias = ffi.cast(intPointer, value)
+        local representation = tostring(alias)
+        assert(type(representation) == "string", "metatype tostring should return a string")
+        assert(representation:find("int*", 1, true) ~= nil, "custom tostring should include prefix")
+    end)
+
+    test("ffi.abi exposes platform information", function()
+        local is32, is64 = ffi.abi("32bit"), ffi.abi("64bit")
+        assert(is32 ~= is64, "exactly one of 32bit/64bit must be true")
+
+        local le, be = ffi.abi("le", "be")
+        assert(le ~= be, "endianness flags must be mutually exclusive")
+
+        assert(type(ffi.os) == "string" and #ffi.os > 0, "ffi.os must be a non-empty string")
+        assert(type(ffi.arch) == "string" and #ffi.arch > 0, "ffi.arch must be a non-empty string")
+
+        local ok, err = pcall(function()
+            ffi.abi("not-a-real-flag")
+        end)
+        assertEqual(ok, false)
+        assert(type(err) == "string")
+        assert(err:find("unknown ABI attribute", 1, true) ~= nil)
+    end)
 end


### PR DESCRIPTION
## Summary
- expose os, arch, and ABI flags from the native layer for use by ffi.abi/ffi.os/ffi.arch
- add library caching, metamethod propagation, and garbage-collection finalizers to the Luau ffi implementation
- update documentation, progress tracking, and runtime specs to cover the new behavior

## Testing
- cargo run -p lune -- run packages/ffi/tests/_runner.luau

------
https://chatgpt.com/codex/tasks/task_e_68dab8534d188326a8c28ac7077ec26c