### PR TITLE
Add callback support to Lune FFI

### DIFF
--- a/crates/lune-std-ffi/build.rs
+++ b/crates/lune-std-ffi/build.rs
@@ -43,4 +43,8 @@ fn main() {
     build.file(native_dir.join("luneffi_testbridge.c"));
 
     build.compile("luneffi_loader");
+
+    if cfg!(not(target_os = "windows")) {
+        println!("cargo:rustc-link-arg=-Wl,--export-dynamic");
+    }
 }

--- a/crates/lune-std-ffi/src/callback.rs
+++ b/crates/lune-std-ffi/src/callback.rs
@@ -1,0 +1,384 @@
+use std::ffi::c_void;
+use std::ptr;
+
+use libffi::middle::Closure;
+use mlua::RegistryKey;
+use mlua::prelude::*;
+
+use crate::signature::{CType, Signature};
+use crate::types::{self, TypeCode};
+
+const CALLBACK_RESULT_SIZE: usize = 16;
+
+struct CallbackData {
+    lua: Lua,
+    function_key: Option<RegistryKey>,
+    signature: Signature,
+}
+
+impl CallbackData {
+    fn new(lua: Lua, signature: Signature, function_key: RegistryKey) -> Self {
+        Self {
+            lua,
+            function_key: Some(function_key),
+            signature,
+        }
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn get_function(&self) -> LuaResult<LuaFunction> {
+        let key = self
+            .function_key
+            .as_ref()
+            .ok_or_else(|| LuaError::runtime("callback function has been released".to_string()))?;
+        self.lua.registry_value(key)
+    }
+
+    fn read_argument(
+        &self,
+        args: *const *const c_void,
+        index: usize,
+        ty: &CType,
+    ) -> LuaResult<LuaValue> {
+        unsafe {
+            let arg_ptr = *args.add(index);
+            match ty.code() {
+                TypeCode::Void => Err(LuaError::runtime(
+                    "void type cannot be used as a callback argument".to_string(),
+                )),
+                TypeCode::Int8 => Ok(LuaValue::Integer(*(arg_ptr as *const i8) as i64)),
+                TypeCode::UInt8 => Ok(LuaValue::Integer(*(arg_ptr as *const u8) as i64)),
+                TypeCode::Int16 => Ok(LuaValue::Integer(*(arg_ptr as *const i16) as i64)),
+                TypeCode::UInt16 => Ok(LuaValue::Integer(*(arg_ptr as *const u16) as i64)),
+                TypeCode::Int32 => Ok(LuaValue::Integer(*(arg_ptr as *const i32) as i64)),
+                TypeCode::UInt32 => Ok(LuaValue::Integer(*(arg_ptr as *const u32) as i64)),
+                TypeCode::Int64 => Ok(LuaValue::Integer(*(arg_ptr as *const i64))),
+                TypeCode::UInt64 => {
+                    let value = *(arg_ptr as *const u64);
+                    if value <= i64::MAX as u64 {
+                        Ok(LuaValue::Integer(value as i64))
+                    } else {
+                        Ok(LuaValue::Number(value as f64))
+                    }
+                }
+                TypeCode::IntPtr => {
+                    if usize::BITS == 64 {
+                        Ok(LuaValue::Integer(*(arg_ptr as *const i64)))
+                    } else {
+                        Ok(LuaValue::Integer(*(arg_ptr as *const i32) as i64))
+                    }
+                }
+                TypeCode::UIntPtr => {
+                    if usize::BITS == 64 {
+                        let value = *(arg_ptr as *const u64);
+                        if value <= i64::MAX as u64 {
+                            Ok(LuaValue::Integer(value as i64))
+                        } else {
+                            Ok(LuaValue::Number(value as f64))
+                        }
+                    } else {
+                        Ok(LuaValue::Integer(*(arg_ptr as *const u32) as i64))
+                    }
+                }
+                TypeCode::Float32 => Ok(LuaValue::Number(*(arg_ptr as *const f32) as f64)),
+                TypeCode::Float64 => Ok(LuaValue::Number(*(arg_ptr as *const f64))),
+                TypeCode::Pointer => {
+                    let value = *(arg_ptr as *const *mut c_void);
+                    if value.is_null() {
+                        Ok(LuaValue::Nil)
+                    } else {
+                        Ok(LuaValue::LightUserData(LuaLightUserData(value)))
+                    }
+                }
+            }
+        }
+    }
+
+    fn pointer_from_value(&self, value: &LuaValue) -> LuaResult<*mut c_void> {
+        match value {
+            LuaValue::Nil => Ok(ptr::null_mut()),
+            LuaValue::LightUserData(ptr) => Ok(ptr.0),
+            LuaValue::Boolean(false) => Ok(ptr::null_mut()),
+            LuaValue::Boolean(true) => Err(LuaError::runtime(
+                "cannot convert boolean 'true' to pointer".to_string(),
+            )),
+            LuaValue::Integer(i) => {
+                if *i < 0 {
+                    return Err(LuaError::runtime(
+                        "pointer value must be non-negative".to_string(),
+                    ));
+                }
+                Ok((*i as u64) as usize as *mut c_void)
+            }
+            LuaValue::Number(n) => {
+                if !n.is_finite() {
+                    return Err(LuaError::runtime(
+                        "pointer value must be finite".to_string(),
+                    ));
+                }
+                if *n < 0.0 {
+                    return Err(LuaError::runtime(
+                        "pointer value must be non-negative".to_string(),
+                    ));
+                }
+                if (n.trunc() - n).abs() > f64::EPSILON {
+                    return Err(LuaError::runtime(
+                        "pointer value must be integral".to_string(),
+                    ));
+                }
+                Ok((*n as u64) as usize as *mut c_void)
+            }
+            LuaValue::Table(table) => {
+                let marker = table.raw_get::<LuaValue>("__ffi_cdata")?;
+                if !matches!(marker, LuaValue::Boolean(true)) {
+                    return Err(LuaError::runtime(
+                        "cannot convert table value to pointer".to_string(),
+                    ));
+                }
+                let inner = table.raw_get::<LuaValue>("__ptr")?;
+                match inner {
+                    LuaValue::LightUserData(ptr) => Ok(ptr.0),
+                    LuaValue::Nil => Ok(ptr::null_mut()),
+                    other => Err(LuaError::runtime(format!(
+                        "cdata object missing native pointer (found {other:?})",
+                    ))),
+                }
+            }
+            other => Err(LuaError::runtime(format!(
+                "cannot convert value {other:?} to pointer",
+            ))),
+        }
+    }
+
+    fn write_result(
+        &self,
+        buffer: &mut [u8; CALLBACK_RESULT_SIZE],
+        value: LuaValue,
+    ) -> LuaResult<()> {
+        buffer.fill(0);
+        match self.signature().result().code() {
+            TypeCode::Void => Ok(()),
+            TypeCode::Int8 => {
+                let v = types::clamp_signed(types::lua_value_to_i64(&value)?, 8)? as i8;
+                buffer[..1].copy_from_slice(&v.to_ne_bytes());
+                Ok(())
+            }
+            TypeCode::UInt8 => {
+                let v = types::clamp_unsigned(types::lua_value_to_u64(&value)?, 8)? as u8;
+                buffer[..1].copy_from_slice(&v.to_ne_bytes());
+                Ok(())
+            }
+            TypeCode::Int16 => {
+                let v = types::clamp_signed(types::lua_value_to_i64(&value)?, 16)? as i16;
+                buffer[..2].copy_from_slice(&v.to_ne_bytes());
+                Ok(())
+            }
+            TypeCode::UInt16 => {
+                let v = types::clamp_unsigned(types::lua_value_to_u64(&value)?, 16)? as u16;
+                buffer[..2].copy_from_slice(&v.to_ne_bytes());
+                Ok(())
+            }
+            TypeCode::Int32 => {
+                let v = types::clamp_signed(types::lua_value_to_i64(&value)?, 32)? as i32;
+                buffer[..4].copy_from_slice(&v.to_ne_bytes());
+                Ok(())
+            }
+            TypeCode::UInt32 => {
+                let v = types::clamp_unsigned(types::lua_value_to_u64(&value)?, 32)? as u32;
+                buffer[..4].copy_from_slice(&v.to_ne_bytes());
+                Ok(())
+            }
+            TypeCode::Int64 => {
+                let v = types::lua_value_to_i64(&value)?;
+                buffer[..8].copy_from_slice(&v.to_ne_bytes());
+                Ok(())
+            }
+            TypeCode::UInt64 => {
+                let v = types::lua_value_to_u64(&value)?;
+                buffer[..8].copy_from_slice(&v.to_ne_bytes());
+                Ok(())
+            }
+            TypeCode::IntPtr => {
+                let bits = usize::BITS;
+                let value = types::clamp_signed(types::lua_value_to_i64(&value)?, bits)?;
+                if bits == 64 {
+                    buffer[..8].copy_from_slice(&value.to_ne_bytes());
+                } else {
+                    let narrowed = value as i32;
+                    buffer[..4].copy_from_slice(&narrowed.to_ne_bytes());
+                }
+                Ok(())
+            }
+            TypeCode::UIntPtr => {
+                let bits = usize::BITS;
+                let value = types::clamp_unsigned(types::lua_value_to_u64(&value)?, bits)?;
+                if bits == 64 {
+                    buffer[..8].copy_from_slice(&value.to_ne_bytes());
+                } else {
+                    let narrowed = value as u32;
+                    buffer[..4].copy_from_slice(&narrowed.to_ne_bytes());
+                }
+                Ok(())
+            }
+            TypeCode::Float32 => {
+                let v = match value {
+                    LuaValue::Number(n) => n as f32,
+                    LuaValue::Integer(i) => i as f32,
+                    LuaValue::Boolean(b) => {
+                        if b {
+                            1.0
+                        } else {
+                            0.0
+                        }
+                    }
+                    other => {
+                        return Err(LuaError::runtime(format!(
+                            "expected numeric value for float result, got {other:?}"
+                        )));
+                    }
+                };
+                buffer[..4].copy_from_slice(&v.to_ne_bytes());
+                Ok(())
+            }
+            TypeCode::Float64 => {
+                let v = match value {
+                    LuaValue::Number(n) => n,
+                    LuaValue::Integer(i) => i as f64,
+                    LuaValue::Boolean(b) => {
+                        if b {
+                            1.0
+                        } else {
+                            0.0
+                        }
+                    }
+                    other => {
+                        return Err(LuaError::runtime(format!(
+                            "expected numeric value for double result, got {other:?}"
+                        )));
+                    }
+                };
+                buffer[..8].copy_from_slice(&v.to_ne_bytes());
+                Ok(())
+            }
+            TypeCode::Pointer => {
+                let ptr = self.pointer_from_value(&value)?;
+                let bytes = (ptr as usize).to_ne_bytes();
+                let size = std::mem::size_of::<*mut c_void>();
+                buffer[..size].copy_from_slice(&bytes[..size]);
+                Ok(())
+            }
+        }
+    }
+
+    fn invoke(
+        &mut self,
+        result: &mut [u8; CALLBACK_RESULT_SIZE],
+        args: *const *const c_void,
+    ) -> LuaResult<()> {
+        let mut values = Vec::with_capacity(self.signature().args().len());
+        for (index, ty) in self.signature().args().iter().enumerate() {
+            let value = self.read_argument(args, index, ty)?;
+            values.push(value);
+        }
+        let lua_args = LuaMultiValue::from_vec(values);
+        let callback = self.get_function()?;
+        let returned = callback.call::<LuaValue>(lua_args)?;
+        self.write_result(result, returned)
+    }
+
+    fn report_error(&self, err: LuaError) {
+        let message = format!("ffi: error in callback: {err}");
+        let globals = self.lua.globals();
+        if let Ok(warn) = globals.get::<LuaFunction>("warn") {
+            let _ = warn.call::<()>(message.clone());
+            return;
+        }
+        eprintln!("{message}");
+    }
+}
+
+struct CallbackHandle {
+    closure: Option<Closure<'static>>,
+    data: *mut CallbackData,
+}
+
+impl CallbackHandle {
+    fn new(
+        lua: &Lua,
+        signature: Signature,
+        func: LuaFunction,
+    ) -> LuaResult<(Self, LuaLightUserData)> {
+        if signature.is_variadic() {
+            return Err(LuaError::runtime(
+                "TODO(@lune/ffi/callback): variadic callbacks not supported yet".to_string(),
+            ));
+        }
+
+        let arg_types = signature.arg_types();
+        let cif = signature.build_cif(&arg_types);
+        let registry_key = lua.create_registry_value(func)?;
+        let data = CallbackData::new(lua.clone(), signature, registry_key);
+        let data_ptr = Box::into_raw(Box::new(data));
+        let closure = Closure::new_mut(cif, callback_trampoline, unsafe { &mut *data_ptr });
+        let code_ptr = closure.code_ptr();
+        let raw_ptr = *code_ptr as *const () as *mut c_void;
+        Ok((
+            Self {
+                closure: Some(closure),
+                data: data_ptr,
+            },
+            LuaLightUserData(raw_ptr),
+        ))
+    }
+}
+
+impl Drop for CallbackHandle {
+    fn drop(&mut self) {
+        unsafe {
+            if let Some(closure) = self.closure.take() {
+                drop(closure);
+            }
+            if !self.data.is_null() {
+                let mut data = Box::from_raw(self.data);
+                if let Some(key) = data.function_key.take() {
+                    if let Err(err) = data.lua.remove_registry_value(key) {
+                        eprintln!("ffi: failed to remove callback registry key: {err}");
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl LuaUserData for CallbackHandle {}
+
+unsafe extern "C" fn callback_trampoline(
+    _cif: &libffi::low::ffi_cif,
+    result: &mut [u8; CALLBACK_RESULT_SIZE],
+    args: *const *const c_void,
+    userdata: &mut CallbackData,
+) {
+    result.fill(0);
+    if let Err(err) = userdata.invoke(result, args) {
+        userdata.report_error(err);
+    }
+}
+
+pub fn register(lua: &Lua, exports: &LuaTable) -> LuaResult<()> {
+    let factory =
+        lua.create_function(|lua, (signature_table, func): (LuaTable, LuaFunction)| {
+            let signature = Signature::from_table(signature_table)?;
+            let (handle, ptr) = CallbackHandle::new(lua, signature, func)?;
+            let userdata = lua.create_userdata(handle)?;
+            Ok(LuaMultiValue::from_vec(vec![
+                LuaValue::LightUserData(ptr),
+                LuaValue::UserData(userdata),
+            ]))
+        })?;
+
+    exports.set("createCallback", factory)?;
+    Ok(())
+}

--- a/crates/lune-std-ffi/src/lib.rs
+++ b/crates/lune-std-ffi/src/lib.rs
@@ -3,7 +3,9 @@
 use mlua::prelude::*;
 
 mod call;
+mod callback;
 mod native;
+mod signature;
 mod types;
 
 const MODULE_SOURCE: &str = include_str!(concat!(

--- a/crates/lune-std-ffi/src/native.rs
+++ b/crates/lune-std-ffi/src/native.rs
@@ -6,7 +6,20 @@ use std::slice;
 use mlua::prelude::*;
 
 use crate::call;
+use crate::callback;
 use crate::types::{self, TypeCode};
+
+type TestCallback = unsafe extern "C" fn(c_int) -> c_int;
+
+#[allow(dead_code)]
+unsafe extern "C" {
+    fn luneffi_test_call_callback(cb: Option<TestCallback>, value: c_int) -> c_int;
+}
+
+#[used]
+#[allow(dead_code)]
+static LUNEFFI_KEEP_TEST_CALLBACK: unsafe extern "C" fn(Option<TestCallback>, c_int) -> c_int =
+    luneffi_test_call_callback;
 
 use libc::{calloc, free, memcpy, size_t};
 
@@ -559,6 +572,8 @@ pub fn create(lua: &Lua) -> LuaResult<LuaTable> {
         },
     )?;
     table.set("call", call_fn)?;
+
+    callback::register(lua, &table)?;
 
     Ok(table)
 }

--- a/crates/lune-std-ffi/src/signature.rs
+++ b/crates/lune-std-ffi/src/signature.rs
@@ -1,0 +1,224 @@
+use cfg_if::cfg_if;
+use libffi::middle::{self, Cif, Type};
+use mlua::prelude::*;
+
+use crate::types::{self, TypeCode};
+
+#[derive(Clone, Debug)]
+pub struct CType {
+    pub(crate) code: TypeCode,
+}
+
+impl CType {
+    pub(crate) fn from_lua(value: LuaValue) -> LuaResult<Self> {
+        match value {
+            LuaValue::String(code) => {
+                let normalized = types::normalize_code(code.to_str()?.as_ref());
+                let ty = TypeCode::from_code(&normalized)?;
+                Ok(Self { code: ty })
+            }
+            LuaValue::Table(table) => {
+                let code: String = table.get("code").map_err(|_| {
+                    LuaError::runtime("Type descriptor missing 'code' field".to_string())
+                })?;
+                let normalized = types::normalize_code(&code);
+                let ty = TypeCode::from_code(&normalized)?;
+                Ok(Self { code: ty })
+            }
+            other => Err(LuaError::runtime(format!(
+                "Invalid type descriptor (expected table or string, got {other:?})"
+            ))),
+        }
+    }
+
+    pub(crate) fn to_libffi_type(&self) -> Type {
+        match self.code {
+            TypeCode::Void => Type::void(),
+            TypeCode::Int8 => Type::i8(),
+            TypeCode::UInt8 => Type::u8(),
+            TypeCode::Int16 => Type::i16(),
+            TypeCode::UInt16 => Type::u16(),
+            TypeCode::Int32 => Type::i32(),
+            TypeCode::UInt32 => Type::u32(),
+            TypeCode::Int64 => Type::i64(),
+            TypeCode::UInt64 => Type::u64(),
+            TypeCode::IntPtr => {
+                if cfg!(target_pointer_width = "64") {
+                    Type::i64()
+                } else {
+                    Type::i32()
+                }
+            }
+            TypeCode::UIntPtr => {
+                if cfg!(target_pointer_width = "64") {
+                    Type::u64()
+                } else {
+                    Type::u32()
+                }
+            }
+            TypeCode::Float32 => Type::f32(),
+            TypeCode::Float64 => Type::f64(),
+            TypeCode::Pointer => Type::pointer(),
+        }
+    }
+
+    pub(crate) fn code(&self) -> TypeCode {
+        self.code
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum AbiChoice {
+    Explicit(middle::FfiAbi),
+    Default,
+}
+
+impl AbiChoice {
+    pub(crate) fn from_option(value: Option<String>) -> LuaResult<Self> {
+        match value.as_deref() {
+            None | Some("cdecl") | Some("default") => Ok(AbiChoice::Default),
+            Some("sysv") => {
+                cfg_if! {
+                    if #[cfg(all(target_arch = "x86_64", unix))] {
+                        Ok(AbiChoice::Explicit(libffi::raw::ffi_abi_FFI_UNIX64))
+                    } else if #[cfg(any(
+                        target_arch = "x86",
+                        target_arch = "arm",
+                        target_arch = "aarch64",
+                        target_arch = "powerpc",
+                    ))] {
+                        Ok(AbiChoice::Explicit(libffi::raw::ffi_abi_FFI_SYSV))
+                    } else if #[cfg(all(target_os = "windows", target_arch = "x86_64"))] {
+                        Ok(AbiChoice::Explicit(libffi::raw::ffi_abi_FFI_WIN64))
+                    } else {
+                        Err(LuaError::runtime("ABI 'sysv' not supported on this target".to_string()))
+                    }
+                }
+            }
+            Some("stdcall") => {
+                cfg_if! {
+                    if #[cfg(any(target_arch = "x86"))] {
+                        Ok(AbiChoice::Explicit(libffi::raw::ffi_abi_FFI_STDCALL))
+                    } else {
+                        Err(LuaError::runtime("ABI 'stdcall' requires x86 architecture".to_string()))
+                    }
+                }
+            }
+            Some("ms_abi") | Some("ms_cdecl") => {
+                cfg_if! {
+                    if #[cfg(all(target_os = "windows", target_arch = "x86"))] {
+                        Ok(AbiChoice::Explicit(libffi::raw::ffi_abi_FFI_MS_CDECL))
+                    } else if #[cfg(all(target_os = "windows", target_arch = "x86_64"))] {
+                        Ok(AbiChoice::Explicit(libffi::raw::ffi_abi_FFI_WIN64))
+                    } else {
+                        Err(LuaError::runtime("ABI 'ms_abi' only available on Windows targets".to_string()))
+                    }
+                }
+            }
+            Some("win64") => {
+                cfg_if! {
+                    if #[cfg(target_os = "windows")] {
+                        Ok(AbiChoice::Explicit(libffi::raw::ffi_abi_FFI_WIN64))
+                    } else {
+                        Err(LuaError::runtime("ABI 'win64' only available on Windows targets".to_string()))
+                    }
+                }
+            }
+            Some(other) => Err(LuaError::runtime(format!("Unsupported ABI '{other}'"))),
+        }
+    }
+
+    pub(crate) fn explicit(self) -> Option<middle::FfiAbi> {
+        match self {
+            AbiChoice::Explicit(abi) => Some(abi),
+            AbiChoice::Default => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Signature {
+    pub(crate) abi: AbiChoice,
+    pub(crate) result: CType,
+    pub(crate) args: Vec<CType>,
+    pub(crate) variadic: bool,
+    pub(crate) fixed_count: usize,
+}
+
+impl Signature {
+    pub(crate) fn from_table(table: LuaTable) -> LuaResult<Self> {
+        let abi = AbiChoice::from_option(table.get::<Option<String>>("abi")?)?;
+        let result_value: LuaValue = table.get("result")?;
+        let result = CType::from_lua(result_value)?;
+
+        let args_table: LuaTable = table.get("args")?;
+        let mut args = Vec::with_capacity(args_table.raw_len() as usize);
+        for value in args_table.sequence_values::<LuaValue>() {
+            let value = value?;
+            args.push(CType::from_lua(value)?);
+        }
+
+        let variadic = table.get::<Option<bool>>("variadic")?.unwrap_or(false);
+        let fixed_count = table
+            .get::<Option<u32>>("fixedCount")?
+            .map_or(args.len(), |n| n as usize);
+
+        if fixed_count > args.len() {
+            return Err(LuaError::runtime(format!(
+                "Invalid signature: fixedCount ({fixed_count}) exceeds number of arguments ({})",
+                args.len()
+            )));
+        }
+
+        if !variadic && fixed_count != args.len() {
+            return Err(LuaError::runtime(
+                "Invalid signature: fixedCount must equal number of arguments for non-variadic functions"
+                    .to_string(),
+            ));
+        }
+
+        Ok(Signature {
+            abi,
+            result,
+            args,
+            variadic,
+            fixed_count,
+        })
+    }
+
+    pub(crate) fn args(&self) -> &[CType] {
+        &self.args
+    }
+
+    pub(crate) fn result(&self) -> &CType {
+        &self.result
+    }
+
+    pub(crate) fn is_variadic(&self) -> bool {
+        self.variadic
+    }
+
+    pub(crate) fn fixed_count(&self) -> usize {
+        self.fixed_count
+    }
+
+    pub(crate) fn arg_types(&self) -> Vec<Type> {
+        self.args.iter().map(CType::to_libffi_type).collect()
+    }
+
+    pub(crate) fn build_cif(&self, arg_types: &[Type]) -> Cif {
+        let result_type = self.result.to_libffi_type();
+
+        let mut cif = if self.variadic {
+            Cif::new_variadic(arg_types.iter().cloned(), self.fixed_count, result_type)
+        } else {
+            Cif::new(arg_types.iter().cloned(), result_type)
+        };
+
+        if let Some(explicit) = self.abi.explicit() {
+            cif.set_abi(explicit);
+        }
+
+        cif
+    }
+}

--- a/crates/lune-std-ffi/tests/runtime_luau.rs
+++ b/crates/lune-std-ffi/tests/runtime_luau.rs
@@ -1,0 +1,85 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use mlua::prelude::*;
+
+fn register_script_module(lua: &Lua, preload: &LuaTable, name: &str, path: &Path) -> LuaResult<()> {
+    let source = fs::read_to_string(path)
+        .map_err(|err| LuaError::external(format!("failed to read {path:?}: {err}")))?;
+    let chunk_name = path.display().to_string();
+    let loader = lua.create_function(move |lua, ()| {
+        lua.load(&source).set_name(&chunk_name).call::<LuaValue>(())
+    })?;
+    preload.set(name, loader)
+}
+
+#[test]
+fn runtime_spec_passes() -> LuaResult<()> {
+    let lua = Lua::new();
+    let module = lune_std_ffi::module(lua.clone())?;
+
+    let preload = lua.create_table()?;
+
+    let module_key = lua.create_registry_value(module)?;
+    let module_loader = lua.create_function(move |lua, ()| {
+        let module: LuaTable = lua.registry_value(&module_key)?;
+        Ok(module)
+    })?;
+    preload.set("@lune/ffi", module_loader)?;
+
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..");
+    register_script_module(
+        &lua,
+        &preload,
+        "./cdef_spec",
+        &repo_root.join("packages/ffi/tests/cdef_spec.luau"),
+    )?;
+    register_script_module(
+        &lua,
+        &preload,
+        "./runtime_spec",
+        &repo_root.join("packages/ffi/tests/runtime_spec.luau"),
+    )?;
+
+    lua.load(
+        r#"
+local preload = ...
+local loaded = {}
+
+function require(name)
+    if loaded[name] ~= nil then
+        return loaded[name]
+    end
+
+    local loader = preload[name]
+    if loader == nil then
+        error(string.format("module '%s' not found", tostring(name)), 2)
+    end
+
+    local result = loader()
+    loaded[name] = result
+    return result
+end
+"#,
+    )
+    .set_name("ffi/test_bootstrap")
+    .call::<()>(preload.clone())?;
+
+    let runner_path = repo_root
+        .join("packages")
+        .join("ffi")
+        .join("tests")
+        .join("_runner.luau");
+    let script = fs::read_to_string(&runner_path)
+        .map_err(|err| LuaError::external(format!("failed to read {runner_path:?}: {err}")))?;
+
+    lua.load(&script)
+        .set_name("packages/ffi/tests/_runner.luau")
+        .exec()?;
+
+    lua.gc_stop();
+    std::mem::forget(lua);
+    Ok(())
+}

--- a/crates/lune/Cargo.toml
+++ b/crates/lune/Cargo.toml
@@ -8,6 +8,7 @@ description = "A standalone Luau runtime"
 readme = "../../README.md"
 keywords = ["cli", "lua", "luau", "runtime"]
 categories = ["command-line-interface"]
+build = "build.rs"
 
 [[bin]]
 name = "lune"

--- a/crates/lune/build.rs
+++ b/crates/lune/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    #[cfg(not(target_os = "windows"))]
+    println!("cargo:rustc-link-arg=-Wl,--export-dynamic");
+}

--- a/packages/ffi/PROGRESS.md
+++ b/packages/ffi/PROGRESS.md
@@ -9,9 +9,9 @@
 - [x] `ffi.C`, `ffi.load`, symbol cache
 - [x] `ffi.metatype`, `ffi.gc`
 - [x] `ffi.abi`, `ffi.os`, `ffi.arch`
-- [ ] Callback trampolines (Luau → C function pointers) + GC safety
+- [x] Callback trampolines (Luau → C function pointers) + GC safety *(basic unary callbacks, TODO: expand coverage)*
 - [ ] Error/errno handling
-- [ ] Unit & integration tests (incl. tiny C test lib built in CI)
+- [x] Unit & integration tests (incl. tiny C test lib built in CI) *(runtime spec executed via Rust harness)*
 - [ ] Examples & README
 - [ ] CI across macOS/Windows/Linux
 - [ ] Compatibility matrix vs LuaJIT FFI (✅/⚠️/⏳)

--- a/packages/ffi/native/luneffi_testbridge.c
+++ b/packages/ffi/native/luneffi_testbridge.c
@@ -4,11 +4,17 @@
 #include <stddef.h>
 #include <stdio.h>
 
-int luneffi_test_add_ints(int a, int b) {
+#if defined(_WIN32)
+#define LUNEFFI_TEST_EXPORT __declspec(dllexport)
+#else
+#define LUNEFFI_TEST_EXPORT __attribute__((visibility("default")))
+#endif
+
+LUNEFFI_TEST_EXPORT int luneffi_test_add_ints(int a, int b) {
     return a + b;
 }
 
-int luneffi_test_variadic_sum(int count, ...) {
+LUNEFFI_TEST_EXPORT int luneffi_test_variadic_sum(int count, ...) {
     va_list args;
     va_start(args, count);
 
@@ -21,7 +27,7 @@ int luneffi_test_variadic_sum(int count, ...) {
     return (int)total;
 }
 
-int luneffi_test_variadic_format(char* buffer, size_t size, const char* fmt, ...) {
+LUNEFFI_TEST_EXPORT int luneffi_test_variadic_format(char* buffer, size_t size, const char* fmt, ...) {
     if (buffer == NULL || size == 0) {
         return -1;
     }
@@ -31,4 +37,13 @@ int luneffi_test_variadic_format(char* buffer, size_t size, const char* fmt, ...
     int written = vsnprintf(buffer, size, fmt, args);
     va_end(args);
     return written;
+}
+
+typedef int (*luneffi_unary_callback)(int);
+
+LUNEFFI_TEST_EXPORT int luneffi_test_call_callback(luneffi_unary_callback cb, int value) {
+    if (cb == NULL) {
+        return -1;
+    }
+    return cb(value);
 }

--- a/packages/ffi/src/init.luau
+++ b/packages/ffi/src/init.luau
@@ -621,7 +621,196 @@ local function split_tokens(tokens: { Token }, separator: string): { { Token } }
     return parts
 end
 
-local function resolve_type_from_tokens(rawTokens: { Token }): CType
+local resolve_type_from_tokens: (rawTokens: { Token }) -> CType
+
+local function parse_parameter_descriptor(sequence: { Token }): CType
+    local descriptor: CType?
+    local message: string?
+
+    local function attempt(tokensToParse: { Token }): boolean
+        local ok, result = pcall(resolve_type_from_tokens, tokensToParse)
+        if ok then
+            descriptor = result
+            return true
+        end
+        message = result
+        return false
+    end
+
+    if not attempt(sequence) then
+        local last = sequence[#sequence]
+        if last and last.kind == "identifier" and not QUALIFIERS[last.value:lower()] then
+            if #sequence == 1 then
+                error(message or "failed to parse parameter type", 3)
+            end
+
+            local trimmed = table.create(#sequence - 1)
+            for index = 1, #sequence - 1 do
+                trimmed[index] = sequence[index]
+            end
+
+            if not attempt(trimmed) then
+                error(message or "failed to parse parameter type", 3)
+            end
+        else
+            error(message or "failed to parse parameter type", 3)
+        end
+    end
+
+    return descriptor :: CType
+end
+
+local function try_parse_function_pointer(tokens: { Token }): CType?
+    local firstParen: number? = nil
+    for index = 1, #tokens do
+        if tokens[index].value == '(' then
+            firstParen = index
+            break
+        end
+    end
+
+    if not firstParen then
+        return nil
+    end
+
+    local afterOpen = firstParen + 1
+    if afterOpen > #tokens or tokens[afterOpen].value ~= '*' then
+        return nil
+    end
+
+    local depth = 0
+    local closeIndex: number? = nil
+    for index = firstParen, #tokens do
+        local token = tokens[index].value
+        if token == '(' then
+            depth += 1
+        elseif token == ')' then
+            depth -= 1
+            if depth == 0 then
+                closeIndex = index
+                break
+            end
+        end
+    end
+
+    if not closeIndex then
+        error("unterminated function pointer declarator", 3)
+    end
+
+    local starCount = 0
+    for index = firstParen + 1, closeIndex - 1 do
+        local token = tokens[index]
+        if token.value == '*' then
+            starCount += 1
+        elseif token.kind == "identifier" then
+            continue
+        else
+            error("TODO(@lune/ffi/cdef): complex function pointer declarators not supported", 3)
+        end
+    end
+
+    if starCount ~= 1 then
+        error("TODO(@lune/ffi/cdef): function pointer declarators with multiple indirections not supported", 3)
+    end
+
+    local paramStart = closeIndex + 1
+    if paramStart > #tokens or tokens[paramStart].value ~= '(' then
+        return nil
+    end
+
+    local depthParams = 1
+    local paramEnd: number? = nil
+    for index = paramStart + 1, #tokens do
+        local token = tokens[index].value
+        if token == '(' then
+            depthParams += 1
+        elseif token == ')' then
+            depthParams -= 1
+            if depthParams == 0 then
+                paramEnd = index
+                break
+            end
+        end
+    end
+
+    if not paramEnd then
+        error("unterminated parameter list in function pointer", 3)
+    end
+
+    if paramEnd ~= #tokens then
+        error("TODO(@lune/ffi/cdef): trailing tokens after function pointer declarator", 3)
+    end
+
+    local returnTokens = {}
+    for index = 1, firstParen - 1 do
+        returnTokens[index] = tokens[index]
+    end
+
+    if #returnTokens == 0 then
+        error("function pointer missing return type", 3)
+    end
+
+    local returnType = resolve_type_from_tokens(returnTokens)
+
+    local paramTokens = {}
+    for index = paramStart + 1, paramEnd - 1 do
+        paramTokens[#paramTokens + 1] = tokens[index]
+    end
+
+    local args = {}
+    local variadic = false
+    if #paramTokens > 0 then
+        local sequences = split_tokens(paramTokens, ',')
+        for _, sequence in ipairs(sequences) do
+            if #sequence == 0 then
+                continue
+            end
+
+            if #sequence == 1 and sequence[1].value == 'void' and not variadic and #sequences == 1 then
+                continue
+            end
+
+            if #sequence == 1 and sequence[1].value == '...' then
+                variadic = true
+                continue
+            end
+
+            local descriptor = parse_parameter_descriptor(sequence)
+            table.insert(args, descriptor)
+        end
+    end
+
+    local displayParts = table.create(#args)
+    for index = 1, #args do
+        local ty = args[index]
+        displayParts[index] = ty.name or ty.code or string.format("arg%d", index)
+    end
+    if variadic then
+        table.insert(displayParts, "...")
+    end
+
+    local signatureText = table.concat(displayParts, ", ")
+    local functionName = if signatureText == "" then string.format("%s()", returnType.name) else string.format("%s(%s)", returnType.name, signatureText)
+
+    local descriptor: CType & { result: CType, args: { CType }, variadic: boolean?, fixedCount: number?, abi: string? } = {
+        kind = "function",
+        name = string.format("function<%s>", functionName),
+        code = "function",
+        result = returnType,
+        args = args,
+        variadic = variadic,
+        fixedCount = #args,
+    }
+
+    return typeRegistry:makePointer(descriptor)
+end
+
+resolve_type_from_tokens = function(rawTokens: { Token }): CType
+    local maybeFunctionPointer = try_parse_function_pointer(rawTokens)
+    if maybeFunctionPointer then
+        return maybeFunctionPointer
+    end
+
     local values = {}
     for index = 1, #rawTokens do
         values[index] = rawTokens[index].value
@@ -949,37 +1138,7 @@ local function parse_function(statement: string)
                 continue
             end
 
-            local descriptor: CType?
-            local ok = true
-            local message = nil
-
-            local function attempt(tokensToParse)
-                local okParse, result = pcall(resolve_type_from_tokens, tokensToParse)
-                if okParse then
-                    descriptor = result
-                    return true
-                end
-                message = result
-                return false
-            end
-
-            if not attempt(sequence) then
-                local last = sequence[#sequence]
-                if last.kind == "identifier" and not QUALIFIERS[last.value:lower()] then
-                    local trimmed = table.create(#sequence - 1)
-                    for index = 1, #sequence - 1 do
-                        trimmed[index] = sequence[index]
-                    end
-                    ok = attempt(trimmed)
-                else
-                    ok = false
-                end
-            end
-
-            if not ok or not descriptor then
-                error(message or "failed to parse function argument type", 3)
-            end
-
+            local descriptor = parse_parameter_descriptor(sequence)
             table.insert(args, descriptor)
         end
     end
@@ -1005,19 +1164,62 @@ local function parse_typedef(statement: string)
         table.insert(body, tokens[index])
     end
 
+    while #body > 0 and body[#body].value == ';' do
+        table.remove(body)
+    end
+
     if #body == 0 then
         error("typedef missing target type", 3)
     end
 
-    local aliasToken = body[#body]
-    if aliasToken.kind ~= "identifier" then
+    local aliasIndex: number? = nil
+    local parenDepth = 0
+    local bracketDepth = 0
+    local braceDepth = 0
+    for index = #body, 1, -1 do
+        local token = body[index]
+        local value = token.value
+        if value == ')' then
+            parenDepth += 1
+        elseif value == '(' then
+            parenDepth -= 1
+        elseif value == ']' then
+            bracketDepth += 1
+        elseif value == '[' then
+            bracketDepth -= 1
+        elseif value == '}' then
+            braceDepth += 1
+        elseif value == '{' then
+            braceDepth -= 1
+        elseif token.kind == "identifier" then
+            local outside = parenDepth == 0 and bracketDepth == 0 and braceDepth == 0
+            local pointerName = parenDepth == 1
+                and bracketDepth == 0
+                and braceDepth == 0
+                and index > 1
+                and body[index - 1].value == '*'
+
+            if outside or pointerName then
+                aliasIndex = index
+                break
+            end
+        end
+    end
+
+    if not aliasIndex then
         error("typedef target name must be an identifier", 3)
     end
 
+    local aliasToken = body[aliasIndex]
     local alias = aliasToken.value
+
     local typeTokens = table.create(#body - 1)
-    for index = 1, #body - 1 do
-        typeTokens[index] = body[index]
+    local offset = 1
+    for index = 1, #body do
+        if index ~= aliasIndex then
+            typeTokens[offset] = body[index]
+            offset += 1
+        end
     end
 
     if #typeTokens == 0 then
@@ -1026,12 +1228,6 @@ local function parse_typedef(statement: string)
 
     local descriptor
     local ok, message = pcall(function()
-        for index = 1, #typeTokens do
-            if typeTokens[index].value == '(' then
-                error("TODO(@lune/ffi/cdef): function pointer typedefs not implemented", 3)
-            end
-        end
-
         descriptor = parse_type_specifier(typeTokens)
     end)
 
@@ -1133,6 +1329,23 @@ end
 
 local function get_function_signature(name: string): FunctionSignature?
     return registry.functions[name]
+end
+
+local function signature_from_descriptor(descriptor: CType & { result: CType, args: { CType }?, variadic: boolean?, fixedCount: number?, abi: string? }): FunctionSignature
+    local args = descriptor.args or {}
+    local copy = table.create(#args)
+    for index = 1, #args do
+        copy[index] = args[index]
+    end
+    local fixed = if descriptor.fixedCount then descriptor.fixedCount else #copy
+    return {
+        kind = "function",
+        result = descriptor.result,
+        args = copy,
+        abi = descriptor.abi,
+        variadic = descriptor.variadic,
+        fixedCount = fixed,
+    }
 end
 
 local function todo(name: string): ()
@@ -1843,8 +2056,28 @@ function ffi.cast(spec: any, value: any): any
     local descriptor = resolve_ctype(spec)
 
     if descriptor.kind == "pointer" then
+        local base = rawget(descriptor, "base")
+        if base and base.kind == "function" and type(value) == "function" then
+            local signature = signature_from_descriptor(base)
+            local ptr, handle = native.createCallback(signature, value)
+            local cdata = create_cdata(descriptor, ptr, false)
+            if handle ~= nil then
+                rawset(cdata, "__callback_handle", handle)
+            end
+            return cdata
+        end
+
+        local callbackHandle = nil
+        if type(value) == "table" and is_cdata(value) then
+            callbackHandle = rawget(value, "__callback_handle")
+        end
+
         local pointerValue = coerce_pointer_value(value)
-        return create_cdata(descriptor, pointerValue, false)
+        local object = create_cdata(descriptor, pointerValue, false)
+        if callbackHandle ~= nil then
+            rawset(object, "__callback_handle", callbackHandle)
+        end
+        return object
     elseif descriptor.kind == "primitive" then
         return allocate_primitive(descriptor, value)
     end

--- a/packages/ffi/tests/runtime_spec.luau
+++ b/packages/ffi/tests/runtime_spec.luau
@@ -173,6 +173,31 @@ return function(ctx)
         assert(representation:find("int*", 1, true) ~= nil, "custom tostring should include prefix")
     end)
 
+    test("ffi.cast bridges Luau callbacks to C function pointers", function()
+        ffi.cdef([[typedef int (*RuntimeUnary)(int);
+int luneffi_test_call_callback(RuntimeUnary cb, int value);]])
+
+        local cbType = ffi.typeof("RuntimeUnary")
+        local total = 0
+
+        local function handler(x)
+            total += x
+            return total
+        end
+
+        local cb = ffi.cast(cbType, handler)
+        local first = ffi.C.luneffi_test_call_callback(cb, 3)
+        assertEqual(first, 3)
+        assertEqual(total, 3)
+
+        local alias = ffi.cast("void*", cb)
+        cb = nil
+        local restored = ffi.cast(cbType, alias)
+        local second = ffi.C.luneffi_test_call_callback(restored, 4)
+        assertEqual(second, 7)
+        assertEqual(total, 7)
+    end)
+
     test("ffi.abi exposes platform information", function()
         local is32, is64 = ffi.abi("32bit"), ffi.abi("64bit")
         assert(is32 ~= is64, "exactly one of 32bit/64bit must be true")


### PR DESCRIPTION
## Summary
- add shared signature helpers so both the call bridge and callbacks can build libffi CIFs
- implement callback creation/teardown in Rust and expose the factory to Luau
- extend the Luau parser/runtime to understand function pointer typedefs and preserve callback handles in ffi.cast

## Testing
- cargo test -p lune-std-ffi

------
https://chatgpt.com/codex/tasks/task_e_68dabf7755248326b1e822ed610945b8