### PR TITLE
Add ffi example integration test and fix callback cleanup

### DIFF
--- a/crates/lune-std-ffi/Cargo.toml
+++ b/crates/lune-std-ffi/Cargo.toml
@@ -19,3 +19,6 @@ libffi = "4.1.2"
 libc = "0.2"
 
 lune-utils = { version = "0.3.2", path = "../lune-utils" }
+
+[dev-dependencies]
+cc = "1.1"

--- a/crates/lune-std-ffi/src/callback.rs
+++ b/crates/lune-std-ffi/src/callback.rs
@@ -344,9 +344,7 @@ impl Drop for CallbackHandle {
             if !self.data.is_null() {
                 let mut data = Box::from_raw(self.data);
                 if let Some(key) = data.function_key.take() {
-                    if let Err(err) = data.lua.remove_registry_value(key) {
-                        eprintln!("ffi: failed to remove callback registry key: {err}");
-                    }
+                    drop(key);
                 }
             }
         }

--- a/crates/lune-std-ffi/tests/runtime_luau.rs
+++ b/crates/lune-std-ffi/tests/runtime_luau.rs
@@ -3,6 +3,106 @@ use std::path::{Path, PathBuf};
 
 use mlua::prelude::*;
 
+fn build_example_library(repo_root: &Path) -> LuaResult<PathBuf> {
+    let example_source = repo_root
+        .join("packages")
+        .join("ffi")
+        .join("examples")
+        .join("native")
+        .join("example.c");
+
+    let build_dir = repo_root.join("target").join("ffi-example");
+    fs::create_dir_all(&build_dir).map_err(|err| {
+        LuaError::external(format!(
+            "failed to create ffi example build directory {build_dir:?}: {err}"
+        ))
+    })?;
+
+    let mut build = cc::Build::new();
+    build.file(&example_source);
+    build.flag_if_supported("-fPIC");
+    build.opt_level(0);
+    let target = option_env!("TARGET")
+        .map(str::to_owned)
+        .or_else(|| std::env::var("TARGET").ok())
+        .or_else(|| option_env!("HOST").map(str::to_owned))
+        .or_else(|| std::env::var("HOST").ok())
+        .unwrap_or_else(|| {
+            let arch = std::env::consts::ARCH;
+            if cfg!(target_os = "windows") {
+                format!("{arch}-pc-windows-msvc")
+            } else if cfg!(target_os = "macos") {
+                format!("{arch}-apple-darwin")
+            } else if cfg!(target_os = "linux") {
+                format!("{arch}-unknown-linux-gnu")
+            } else {
+                arch.to_string()
+            }
+        });
+    build.target(&target);
+    unsafe {
+        std::env::set_var("TARGET", &target);
+        std::env::set_var("OPT_LEVEL", "0");
+        std::env::set_var("HOST", &target);
+    }
+
+    let objects = build.compile_intermediates();
+    let compiler = build.get_compiler();
+
+    let lib_name = if cfg!(target_os = "windows") {
+        "example.dll"
+    } else if cfg!(target_os = "macos") {
+        "libexample.dylib"
+    } else {
+        "libexample.so"
+    };
+
+    let lib_path = build_dir.join(lib_name);
+    if lib_path.exists() {
+        fs::remove_file(&lib_path).map_err(|err| {
+            LuaError::external(format!(
+                "failed to remove previous ffi example library {lib_path:?}: {err}"
+            ))
+        })?;
+    }
+
+    let mut cmd = compiler.to_command();
+
+    if compiler.is_like_msvc() {
+        for object in &objects {
+            cmd.arg(object);
+        }
+        cmd.arg("/LD");
+        cmd.arg(format!("/Fe{}", lib_path.display()));
+    } else {
+        if cfg!(target_os = "macos") {
+            cmd.arg("-dynamiclib");
+        } else {
+            cmd.arg("-shared");
+        }
+        cmd.arg("-o");
+        cmd.arg(&lib_path);
+        for object in &objects {
+            cmd.arg(object);
+        }
+    }
+
+    let command_display = format!("{cmd:?}");
+    let status = cmd.status().map_err(|err| {
+        LuaError::external(format!(
+            "failed to invoke compiler for ffi example library ({command_display}): {err}"
+        ))
+    })?;
+
+    if !status.success() {
+        return Err(LuaError::external(format!(
+            "ffi example library build failed with status {status} using {command_display}"
+        )));
+    }
+
+    Ok(lib_path)
+}
+
 fn register_script_module(lua: &Lua, preload: &LuaTable, name: &str, path: &Path) -> LuaResult<()> {
     let source = fs::read_to_string(path)
         .map_err(|err| LuaError::external(format!("failed to read {path:?}: {err}")))?;
@@ -15,6 +115,11 @@ fn register_script_module(lua: &Lua, preload: &LuaTable, name: &str, path: &Path
 
 #[test]
 fn runtime_spec_passes() -> LuaResult<()> {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..");
+    let example_library = build_example_library(&repo_root)?;
+
     let lua = Lua::new();
     let module = lune_std_ffi::module(lua.clone())?;
 
@@ -27,9 +132,11 @@ fn runtime_spec_passes() -> LuaResult<()> {
     })?;
     preload.set("@lune/ffi", module_loader)?;
 
-    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("..")
-        .join("..");
+    lua.globals().set(
+        "FFI_EXAMPLE_LIBRARY_PATH",
+        example_library.to_string_lossy().to_string(),
+    )?;
+
     register_script_module(
         &lua,
         &preload,
@@ -41,6 +148,12 @@ fn runtime_spec_passes() -> LuaResult<()> {
         &preload,
         "./runtime_spec",
         &repo_root.join("packages/ffi/tests/runtime_spec.luau"),
+    )?;
+    register_script_module(
+        &lua,
+        &preload,
+        "./example_spec",
+        &repo_root.join("packages/ffi/tests/example_spec.luau"),
     )?;
 
     lua.load(
@@ -79,7 +192,5 @@ end
         .set_name("packages/ffi/tests/_runner.luau")
         .exec()?;
 
-    lua.gc_stop();
-    std::mem::forget(lua);
     Ok(())
 }

--- a/packages/ffi/src/init.luau
+++ b/packages/ffi/src/init.luau
@@ -17,6 +17,15 @@ local function ensure_task_library()
     return globalTask
 end
 
+local function warn_if_available(message: string)
+    local maybeWarn = rawget(_G, "warn")
+    if type(maybeWarn) == "function" then
+        maybeWarn(message)
+    else
+        print(message)
+    end
+end
+
 if type(native) ~= "table" then
     error("native bindings table is required", 2)
 end
@@ -90,6 +99,7 @@ local finalizerStates = {} :: { [number]: LibraryState }
 local finalizerFreeSlots = {} :: { [number]: number }
 local finalizerMaxIndex = 0
 local finalizerLoopActive = false
+local finalizerLoopSupported = true
 
 local function clear_library_state(state: LibraryState)
     state.handle = nil
@@ -107,12 +117,22 @@ end
 
 local function ensure_finalizer_loop()
     if finalizerLoopActive then
-        return
+        return true
+    end
+    if not finalizerLoopSupported then
+        return false
+    end
+
+    local ok, schedulerOrErr = pcall(ensure_task_library)
+    if not ok then
+        finalizerLoopSupported = false
+        warn_if_available("ffi: task library unavailable; library finalizers disabled")
+        return false
     end
 
     finalizerLoopActive = true
 
-    local scheduler = ensure_task_library()
+    local scheduler = schedulerOrErr
     local defer = scheduler.defer
     local wait = scheduler.wait
     if type(defer) ~= "function" or type(wait) ~= "function" then
@@ -154,6 +174,10 @@ local function ensure_finalizer_loop()
 end
 
 local function register_library_finalizer(wrapper: any, state: LibraryState)
+    if not ensure_finalizer_loop() then
+        return
+    end
+
     local slot = table.remove(finalizerFreeSlots)
     if slot == nil then
         finalizerMaxIndex += 1
@@ -163,8 +187,6 @@ local function register_library_finalizer(wrapper: any, state: LibraryState)
     finalizerRefs[slot] = wrapper
     finalizerStates[slot] = state
     state.finalizerIndex = slot
-
-    ensure_finalizer_loop()
 end
 
 local function unregister_library_finalizer(state: LibraryState)
@@ -180,15 +202,6 @@ end
 local function trim(value: string): string
     local stripped = value:gsub("^%s+", "")
     return stripped:gsub("%s+$", "")
-end
-
-local function warn_if_available(message: string)
-    local maybeWarn = rawget(_G, "warn")
-    if type(maybeWarn) == "function" then
-        maybeWarn(message)
-    else
-        print(message)
-    end
 end
 
 type CType = {

--- a/packages/ffi/tests/_runner.luau
+++ b/packages/ffi/tests/_runner.luau
@@ -28,11 +28,13 @@ local registry = {
     ffi = ffi,
     test = test,
     assertEqual = assertEqual,
+    exampleLibraryPath = rawget(_G, "FFI_EXAMPLE_LIBRARY_PATH"),
 }
 
 local modules = {
     require("./cdef_spec"),
     require("./runtime_spec"),
+    require("./example_spec"),
 }
 
 for _, register in ipairs(modules) do

--- a/packages/ffi/tests/example_spec.luau
+++ b/packages/ffi/tests/example_spec.luau
@@ -1,0 +1,38 @@
+return function(ctx)
+    local ffi = ctx.ffi
+    local test = ctx.test
+    local assertEqual = ctx.assertEqual
+    local exampleLibraryPath = ctx.exampleLibraryPath
+
+    test("ffi.load bridges custom shared libraries", function()
+        assert(type(exampleLibraryPath) == "string" and #exampleLibraryPath > 0, "expected example library path")
+
+        ffi.cdef([[typedef int (*ExampleCallback)(int);
+
+int example_add_ints(int a, int b);
+const char* example_greeting(void);
+void example_invoke(ExampleCallback cb, int value);
+]])
+
+        local lib = ffi.load(exampleLibraryPath)
+        assert(type(lib) == "table", "ffi.load should return a library table")
+
+        assertEqual(lib.example_add_ints(9, 5), 14)
+
+        local greeting = ffi.string(lib.example_greeting())
+        assertEqual(greeting, "Hello from libexample")
+
+        local callbackType = ffi.typeof("ExampleCallback")
+        local total = 0
+        local callback = ffi.cast(callbackType, function(value)
+            total += value
+            return total
+        end)
+
+        lib.example_invoke(callback, 3)
+        assertEqual(total, 3)
+
+        lib.example_invoke(callback, 4)
+        assertEqual(total, 7)
+    end)
+end


### PR DESCRIPTION
## Summary
- build the native ffi example during runtime tests and add a Luau spec that loads it via ffi
- disable automatic library finalizers when the task library is missing and log a warning instead
- drop callback registry keys without touching the Lua state to avoid GC panics during shutdown

## Testing
- cargo test -p lune-std-ffi --test runtime_luau -- --nocapture
- cargo test -p lune-std-ffi -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68dbcd8d598083269be3b1dd4fae5043